### PR TITLE
Better installation instruction/script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,14 +42,14 @@ jobs:
           mkdir -p ~/download
           cd ~/download
           wget https://cdn.discordapp.com/attachments/698589325620936736/845499146982129684/mwccarm.zip
-          wget https://cdn.discordapp.com/attachments/698589325620936736/722822401963851797/NitroSDK-3_2-060901.7z
+          wget https://cdn.discordapp.com/attachments/855279572651868170/875195363261292604/NitroSDK-4_2-071210-jp.7z
           unzip mwccarm.zip
           mv mwccarm $GITHUB_WORKSPACE/tools
-          7z x NitroSDK-3_2-060901.7z
-          mv NitroSDK-3_2-060901/tools/bin $GITHUB_WORKSPACE/tools
-          mv NitroSDK-3_2-060901/include/nitro/specfiles/ARM7-TS.lcf.template $GITHUB_WORKSPACE/sub/
-          mv NitroSDK-3_2-060901/include/nitro/specfiles/ARM9-TS.lcf.template $GITHUB_WORKSPACE/
-          mv NitroSDK-3_2-060901/include/nitro/specfiles/mwldarm.response.template $GITHUB_WORKSPACE/
+          7z x NitroSDK-4_2-071210-jp.7z
+          mv NitroSDK-4_2-071210-jp/tools/bin $GITHUB_WORKSPACE/tools
+          mv NitroSDK-4_2-071210-jp/include/nitro/specfiles/ARM7-TS.lcf.template $GITHUB_WORKSPACE/sub/
+          mv NitroSDK-4_2-071210-jp/include/nitro/specfiles/ARM9-TS.lcf.template $GITHUB_WORKSPACE/
+          mv NitroSDK-4_2-071210-jp/include/nitro/specfiles/mwldarm.response.template $GITHUB_WORKSPACE/
         working-directory: ~
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,10 @@ jobs:
           unzip mwccarm.zip
           mv mwccarm $GITHUB_WORKSPACE/tools
           7z x NitroSDK-4_2-071210-jp.7z
-          mv NitroSDK-4_2-071210-jp/tools/bin $GITHUB_WORKSPACE/tools
-          mv NitroSDK-4_2-071210-jp/include/nitro/specfiles/ARM7-TS.lcf.template $GITHUB_WORKSPACE/sub/
-          mv NitroSDK-4_2-071210-jp/include/nitro/specfiles/ARM9-TS.lcf.template $GITHUB_WORKSPACE/
-          mv NitroSDK-4_2-071210-jp/include/nitro/specfiles/mwldarm.response.template $GITHUB_WORKSPACE/
+          mv tools/bin $GITHUB_WORKSPACE/tools
+          mv include/nitro/specfiles/ARM7-TS.lcf.template $GITHUB_WORKSPACE/sub/
+          mv include/nitro/specfiles/ARM9-TS.lcf.template $GITHUB_WORKSPACE/
+          mv include/nitro/specfiles/mwldarm.response.template $GITHUB_WORKSPACE/
         working-directory: ~
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tools/bin/**
 # Build folder
 build/**
 sub/build/**
+toolchain_tmp/
 
 # Icon build files
 *.nbfp

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,17 +6,21 @@ Using a terminal or Git client, clone this repository to your local device. All 
 
 ## 1. Install MWCC compiler
 
-The build system requires the use of the Metrowerks C Compiler versions 2.0/sp2p2 to compile matching files. We cannot distribute the correct compiler here, so join the PRET Discord, download the pinned `mwccarm.zip` zip in `#pokediamond`, and extract it to `tools/`. At the end of this operation, you should have the file `tools/mwccarm/2.0/sp2p2/mwccarm.exe`. Run each of the executables so they ask for a `license.dat`, and provide the one in the zip (it may also ask for it when compiling). This only needs to be done once.
+Step 1 and 2 can also be executed automatically by running `make install_toolchain`
+
+The build system requires the use of the Metrowerks C Compiler versions 2.0/sp2p2 to compile matching files. We cannot distribute the correct compiler here, so join the PRET Discord, download the pinned `mwccarm.zip` zip in `#pokediamond`, and extract it to `tools/`. At the end of this operation, you should have the file `tools/mwccarm/2.0/sp2p2/mwccarm.exe`.
 
 In the future, a GCC option will be available so MWCC is not required to build; however, it is required for a matching ROM.
 
 ## 2. Install Nitro SDK
 
-As with the compiler, the Nitro SDK is proprietary and cannot be distributed here. Download the `NitroSDK-4_2-071210-jp.7z` file pinned in the PRET Discord. Extract and copy the folder `tools/bin` from the Nitro SDK into the folder `tools` in your `pmd-sky` clone. At the end of this operation, you should have the file `tools/bin/makelcf.exe` inside your `pmd-sky` clone. Finally, copy `include/nitro/specfiles/ARM7-TS.lcf.template` into the subdirectory `sub`, and `include/nitro/specfiles/ARM9-TS.lcf.template` and `include/nitro/specfiles/mwldarm.response.template` into the project root.
+As with the compiler, the Nitro SDK is proprietary and cannot be distributed here. Download the `NitroSDK-4_2-071210-jp.7z` file pinned in the PRET Discord in `#pokeheartgold`. Extract and copy the folder `tools/bin` from the Nitro SDK into the folder `tools` in your `pmd-sky` clone. At the end of this operation, you should have the file `tools/bin/makelcf.exe` inside your `pmd-sky` clone. Finally, copy `include/nitro/specfiles/ARM7-TS.lcf.template` into the subdirectory `sub`, and `include/nitro/specfiles/ARM9-TS.lcf.template` and `include/nitro/specfiles/mwldarm.response.template` into the project root.
 
 ## 3. Dependencies
 
 ### Linux
+
+If you have Nix with flake support enabled, you can also use `nix develop` to start an environment with the tools present.
 
 Building the ROM requires the following packages. If you cannot find one or more of these using your package distribution, it may be under a different name.
 

--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,17 @@ $(BANNER): $(BANNER_SPEC) $(ICON_PNG:%.png=%.nbfp) $(ICON_PNG:%.png=%.nbfc)
 
 compare: @$(MAKE) COMPARE=1
 
-.PHONY: compare
+install_toolchain:
+	rm -rf toolchain_tmp
+	mkdir -p toolchain_tmp
+	wget https://cdn.discordapp.com/attachments/698589325620936736/845499146982129684/mwccarm.zip -O toolchain_tmp/mwccarm.zip
+	wget https://cdn.discordapp.com/attachments/855279572651868170/875195363261292604/NitroSDK-4_2-071210-jp.7z -O toolchain_tmp/NitroSDK-4_2-071210-jp.7z
+	unzip -o toolchain_tmp/mwccarm.zip -d tools
+	7z x toolchain_tmp/NitroSDK-4_2-071210-jp.7z -otoolchain_tmp/nitro_sdk -y
+	mv toolchain_tmp/nitro_sdk/tools/bin/* tools/bin
+	mv toolchain_tmp/nitro_sdk/include/nitro/specfiles/ARM7-TS.lcf.template sub/
+	mv toolchain_tmp/nitro_sdk/include/nitro/specfiles/ARM9-TS.lcf.template .
+	mv toolchain_tmp/nitro_sdk/include/nitro/specfiles/mwldarm.response.template .
+	rm -r toolchain_tmp
+
+.PHONY: compare install_toolchain

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693145325,
+        "narHash": "sha256-Gat9xskErH1zOcLjYMhSDBo0JTBZKfGS0xJlIRnj6Rc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cddebdb60de376c1bdb7a4e6ee3d98355453fe56",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "PMD-SKY decomp nix development shell";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.simpleFlake rec {
+      inherit self nixpkgs;
+      name = "pmd-sky-shell";
+      # Native shell instead of an arm-cross shell so utilities are properly compiled for host
+      shell = { pkgs }: pkgs.mkShell {
+        inherit name;
+
+        nativeBuildInputs = [
+          pkgs.git
+          pkgs.wineWowPackages.base # wine with both 32 and 64 bits support
+          pkgs.python3
+          pkgs.pkg-config
+          pkgs.pkgsCross.arm-embedded.stdenv.cc.bintools # binutils
+        ];
+
+        buildInputs = [
+          pkgs.libpng
+          pkgs.pugixml
+        ];
+      };
+    };
+}


### PR DESCRIPTION
The compiler never asked to enter a license, and adapted what was present in the build.yml file into the Makefile.

I now obtain a ROM that is properly built and checksumed with ``make run``.

Also include an (optional) nix developement shell. Flakes is in beta since about 2 years, but it seems most of the users have enabled them anyway. Should become stable in less than a years given the roadmap, but there has been no breaking change since a long time.