### PR TITLE
Clarify scope of include/LICENSE.txt

### DIFF
--- a/include/LICENSE.txt
+++ b/include/LICENSE.txt
@@ -1,8 +1,14 @@
-NOTE: The following license applies only to the files within this directory.
+NOTE: The following license applies only to relevant information in this
+directory copied from the pmdsky-debug project, including, but not limited to:
+- certain symbol names
+- certain docstrings and comments
+- certain struct definitions
+- certain enum definitions
+- certain function prototypes
 
 MIT License
 
-Copyright (c) 2022 UsernameFodder
+Copyright (c) 2022 pmdsky-debug contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The existing license text could be misinterpreted as pmdsky-debug owning everything in the directory, which isn't true. Modify the note to clarify the scope of the license's application.

As the one named as the original copyright holder, I'm loosening it for this repository since the portions of work it's using are more naturally attributed to all the pmdsky-debug contributors, not just me.