### PR TITLE
Support syncing BSS symbols to pmdsky-debug

### DIFF
--- a/tools/sync_pmdsky_debug/pmdsky_debug_reader.py
+++ b/tools/sync_pmdsky_debug/pmdsky_debug_reader.py
@@ -114,5 +114,6 @@ def read_pmdsky_debug_symbols() -> Dict[str, Dict[str, Dict[int, SymbolDetails]]
             for file in os.listdir(overlay_folder):
                 if file.endswith('.yml'):
                     read_yaml_symbols(os.path.join(overlay_name, file), str(i))
+    read_yaml_symbols('ram.yml', 'ram')
 
     return pmdsky_debug_symbols

--- a/tools/sync_pmdsky_debug/sync_from_pmdsky_debug.py
+++ b/tools/sync_pmdsky_debug/sync_from_pmdsky_debug.py
@@ -39,6 +39,10 @@ replaced_symbols = set()
 for language, pmdsky_debug_language_symbols in pmdsky_debug_symbols.items():
     xmap_language_symbols = xmap_symbols[language]
     for section_name, pmdsky_debug_section in pmdsky_debug_language_symbols.items():
+        if section_name == 'ram':
+            # We can't distinguish between different types of RAM symbols.
+            # E.g., they could be in the BSS, heap, etc.
+            continue
         if section_name in xmap_language_symbols:
             xmap_section = xmap_language_symbols[section_name]
         else:

--- a/tools/sync_pmdsky_debug/sync_to_pmdsky_debug.py
+++ b/tools/sync_pmdsky_debug/sync_to_pmdsky_debug.py
@@ -70,6 +70,8 @@ def sync_xmap_symbol(address: int, symbol: SymbolDetails, language: str, yaml_ma
             base_symbol_path = 'arm7.yml'
         elif section_name == 'ITCM':
             base_symbol_path = os.path.join('arm9', 'itcm.yml')
+        elif section_name == 'ram':
+            base_symbol_path = 'ram.yml'
         else:
             base_symbol_path = f'overlay{int(section_name):02d}.yml'
 


### PR DESCRIPTION
These data symbols can be added to ram.yml. Since information is lost, it's not possible to go in the other direction, so RAM syncing can only be done TO pmdsky-debug.