### PR TITLE
Add missing dependencies to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,8 @@
           pkgs.python3
           pkgs.pkg-config
           pkgs.pkgsCross.arm-embedded.stdenv.cc.bintools # binutils
+          pkgs.unzip
+          pkgs.p7zip
         ];
 
         buildInputs = [


### PR DESCRIPTION
`make install_toolchain` requires both unzip and p7zip on nixos. List these in the flake.nix so it can work out of the box.