### PR TITLE
Decompile dg_object functions

### DIFF
--- a/asm/include/overlay_29_022DC2B8.inc
+++ b/asm/include/overlay_29_022DC2B8.inc
@@ -91,7 +91,7 @@
 .public ov29_022E15C8
 .public ov29_022E1604
 .public ov29_022E1640
-.public ov29_022E1A84
+.public SetEntityPixelPosXY
 .public ov29_022E2B68
 .public ov29_022E2DFC
 .public ov29_022E34B0

--- a/asm/include/overlay_29_022E1AAC.inc
+++ b/asm/include/overlay_29_022E1AAC.inc
@@ -1,9 +1,7 @@
 #pragma once
-.public _020A1AE8
-.public abs
 .public CanSeeInvisibleMonsters
-.public DrawMinimapTile
 .public DUNGEON_PTR
+.public DrawMinimapTile
 .public DungeonGetSpriteIndex
 .public EntityIsValid__022E1A1C
 .public EntityIsValid__022E32E8
@@ -19,6 +17,12 @@
 .public IsPositionActuallyInSight
 .public IsPositionInSight
 .public ItemIsActive__022E330C
+.public SECONDARY_TERRAIN_TYPES
+.public StringFromId
+.public TeamMemberHasEnabledIqSkill
+.public UpdateMinimap
+.public UpdateTrapsVisibility
+.public abs
 .public ov29_022DE954
 .public ov29_022DE9F8
 .public ov29_022DEA10
@@ -39,11 +43,6 @@
 .public ov29_0237C754
 .public ov29_0237C79C
 .public ov29_0237C84C
-.public SECONDARY_TERRAIN_TYPES
 .public strcpy
-.public StringFromId
 .public sub_02009194
 .public sub_020091B0
-.public TeamMemberHasEnabledIqSkill
-.public UpdateMinimap
-.public UpdateTrapsVisibility

--- a/asm/include/overlay_29_023047DC.inc
+++ b/asm/include/overlay_29_023047DC.inc
@@ -17,7 +17,7 @@
 .public GetTileAtEntity
 .public IsFloorOver
 .public IsWaterTileset
-.public ov29_022E1A90
+.public IncrementEntityPixelPosXY
 .public ov29_022E8104
 .public ov29_022EA370
 .public ov29_022EF9BC

--- a/asm/include/overlay_29_0231F594.inc
+++ b/asm/include/overlay_29_0231F594.inc
@@ -16,8 +16,8 @@
 .public LogMessageByIdWithPopupCheckUser
 .public MemAlloc
 .public MemFree
-.public ov29_022E1A84
-.public ov29_022E1A90
+.public SetEntityPixelPosXY
+.public IncrementEntityPixelPosXY
 .public ov29_022E56A0
 .public ov29_022F62CC
 .public ov29_02304B64

--- a/asm/include/overlay_29_0231FC20.inc
+++ b/asm/include/overlay_29_0231FC20.inc
@@ -14,7 +14,7 @@
 .public LogMessageByIdWithPopupCheckUserTarget
 .public MoveMonsterToPos
 .public ov10_022C4570
-.public ov29_022E1A90
+.public IncrementEntityPixelPosXY
 .public ov29_022E56A0
 .public ov29_022F9C74
 .public ov29_022FFB90

--- a/asm/include/overlay_29_023201A0.inc
+++ b/asm/include/overlay_29_023201A0.inc
@@ -16,7 +16,7 @@
 .public LogMessageByIdWithPopupCheckUser
 .public LogMessageByIdWithPopupCheckUserTarget
 .public MoveMonsterToPos
-.public ov29_022E1A90
+.public IncrementEntityPixelPosXY
 .public ov29_022E5560
 .public ov29_022E55F0
 .public ov29_022E56A0

--- a/asm/include/overlay_29_0232A3FC.inc
+++ b/asm/include/overlay_29_0232A3FC.inc
@@ -63,8 +63,8 @@
 .public ov10_022C5DE0
 .public ov10_022C6321
 .public ov10_022C6322
-.public ov29_022E1A84
-.public ov29_022E1A90
+.public SetEntityPixelPosXY
+.public IncrementEntityPixelPosXY
 .public ov29_022E2CA0
 .public ov29_022ED868
 .public ov29_022F8FF8

--- a/asm/include/overlay_29_023456BC.inc
+++ b/asm/include/overlay_29_023456BC.inc
@@ -62,8 +62,8 @@
 .public ov10_022C48EC
 .public ov10_022C4CD8
 .public ov29_022E09E8
-.public ov29_022E1A84
-.public ov29_022E1A90
+.public SetEntityPixelPosXY
+.public IncrementEntityPixelPosXY
 .public ov29_022E563C
 .public ov29_022E9488
 .public ov29_022EACBC

--- a/asm/include/overlay_29_02347BC8.inc
+++ b/asm/include/overlay_29_02347BC8.inc
@@ -41,7 +41,7 @@
 .public ov29_022E0DE4
 .public ov29_022E0DFC
 .public ov29_022E0E44
-.public ov29_022E1A84
+.public SetEntityPixelPosXY
 .public ov29_022E2CA0
 .public ov29_022E9488
 .public ov29_022FB9BC

--- a/asm/overlay_29_022DC2B8.s
+++ b/asm/overlay_29_022DC2B8.s
@@ -4164,7 +4164,7 @@ _022DF9B0:
 	add r0, sp, #0x18
 	mov r1, r1, lsl #8
 	mov r2, r2, lsl #8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r3, #0
 	mov r0, r4
 	add r1, sp, #0x18

--- a/asm/overlay_29_022E1AAC.s
+++ b/asm/overlay_29_022E1AAC.s
@@ -1,47 +1,7 @@
 	.include "asm/macros.inc"
-	.include "overlay_29_022E1A40.inc"
+	.include "overlay_29_022E1AAC.inc"
 
 	.text
-
-	arm_func_start UpdateEntityPixelPos
-UpdateEntityPixelPos: ; 0x022E1A40
-	cmp r1, #0
-	ldrne r2, [r1]
-	strne r2, [r0, #0xc]
-	ldrne r1, [r1, #4]
-	bne _022E1A7C
-	ldrsh r2, [r0, #4]
-	mov r1, #0x18
-	smulbb r2, r2, r1
-	add r2, r2, #0xc
-	mov r2, r2, lsl #8
-	str r2, [r0, #0xc]
-	ldrsh r2, [r0, #6]
-	smulbb r1, r2, r1
-	add r1, r1, #0x10
-	mov r1, r1, lsl #8
-_022E1A7C:
-	str r1, [r0, #0x10]
-	bx lr
-	arm_func_end UpdateEntityPixelPos
-
-	arm_func_start ov29_022E1A84
-ov29_022E1A84: ; 0x022E1A84
-	str r1, [r0, #0xc]
-	str r2, [r0, #0x10]
-	bx lr
-	arm_func_end ov29_022E1A84
-
-	arm_func_start ov29_022E1A90
-ov29_022E1A90: ; 0x022E1A90
-	ldr r3, [r0, #0xc]
-	add r1, r3, r1
-	str r1, [r0, #0xc]
-	ldr r1, [r0, #0x10]
-	add r1, r1, r2
-	str r1, [r0, #0x10]
-	bx lr
-	arm_func_end ov29_022E1A90
 
 	arm_func_start ov29_022E1AAC
 ov29_022E1AAC: ; 0x022E1AAC

--- a/asm/overlay_29_023047DC.s
+++ b/asm/overlay_29_023047DC.s
@@ -792,7 +792,7 @@ _023051C4:
 	mov r0, r7
 	ldr r1, [r8, #0x10]
 	ldr r2, [r8, #0x14]
-	bl ov29_022E1A90
+	bl IncrementEntityPixelPosXY
 	ldrb r0, [sb, #7]
 	cmp r0, #0
 	beq _02305258

--- a/asm/overlay_29_0231F594.s
+++ b/asm/overlay_29_0231F594.s
@@ -200,7 +200,7 @@ _0231F7A0:
 	add r2, r2, #4
 	mov r1, r1, lsl #8
 	mov r2, r2, lsl #8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r1, #0
 	strh r1, [r5, #0x26]
 	mov r1, #1
@@ -405,7 +405,7 @@ _0231FA9C:
 	ldr r1, [r2, #0x2f4]
 	ldr r2, [r2, #0x2f8]
 	str r0, [sp, #4]
-	bl ov29_022E1A90
+	bl IncrementEntityPixelPosXY
 	mov r0, r8
 	bl sub_020018D0
 	mov r1, #0xc

--- a/asm/overlay_29_0231FC20.s
+++ b/asm/overlay_29_0231FC20.s
@@ -259,7 +259,7 @@ _0231FF84:
 	ldr r1, [sp, #0x18]
 	ldr r2, [sp, #0x1c]
 	mov r0, sb
-	bl ov29_022E1A90
+	bl IncrementEntityPixelPosXY
 	mov r0, sb
 	bl ShouldDisplayEntityWrapper
 	cmp r0, #0

--- a/asm/overlay_29_023201A0.s
+++ b/asm/overlay_29_023201A0.s
@@ -89,7 +89,7 @@ _023202C4:
 	mov r0, sl
 	mov r1, r6
 	mov r2, r7
-	bl ov29_022E1A90
+	bl IncrementEntityPixelPosXY
 	mov r0, sl
 	bl ShouldDisplayEntityWrapper
 	cmp r0, #0

--- a/asm/overlay_29_0232A3FC.s
+++ b/asm/overlay_29_0232A3FC.s
@@ -418,7 +418,7 @@ ov29_0232A834: ; 0x0232A834
 	add r3, r3, #4
 	mov r1, r3, lsl #8
 	mov r2, r2, lsl #8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r0, #0
 	add r1, sp, #8
 	mov r2, r0
@@ -528,7 +528,7 @@ _0232AA28:
 	mov r0, sb
 	mov r1, r5
 	mov r2, r4
-	bl ov29_022E1A90
+	bl IncrementEntityPixelPosXY
 	mov r0, fp
 	bl AdvanceFrame
 	add r6, r6, #1
@@ -627,7 +627,7 @@ _0232ABA0:
 	mov r0, sb
 	mov r1, r5
 	mov r2, r6
-	bl ov29_022E1A90
+	bl IncrementEntityPixelPosXY
 	mov r0, r4
 	bl AdvanceFrame
 	add r7, r7, #1

--- a/asm/overlay_29_023456BC.s
+++ b/asm/overlay_29_023456BC.s
@@ -290,7 +290,7 @@ SpawnDroppedItemWrapper: ; 0x02345A3C
 	add r3, r3, #4
 	mov r1, r3, lsl #8
 	mov r2, r2, lsl #8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r0, #0
 	strh r0, [sp, #0x2e]
 	str r0, [sp]
@@ -595,7 +595,7 @@ _02345E90:
 	mov r1, r7
 	mov r2, r8
 	str r5, [sl, #0x1c]
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r6, #0
 _02345EE0:
 	sub r5, r5, #0x800
@@ -614,7 +614,7 @@ _02345EE0:
 	mov r0, sl
 	mov r1, r7
 	mov r2, r8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r2, #0
 	str r2, [sl, #0x1c]
 	mov r0, sl
@@ -1057,7 +1057,7 @@ _023464C4:
 	add r2, r2, #4
 	mov r1, r1, lsl #8
 	mov r2, r2, lsl #8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r0, #0
 	strh r0, [r6, #0x26]
 	mov r0, r8, lsl #2
@@ -1156,7 +1156,7 @@ _0234665C:
 	ldr r1, [r1, r8, lsl #3]
 	ldr r2, [r2, #4]
 	str r0, [sp, #0xc]
-	bl ov29_022E1A90
+	bl IncrementEntityPixelPosXY
 	mov r0, fp
 	bl sub_020018D0
 	mov r1, #0xc
@@ -2368,7 +2368,7 @@ _023474CC:
 	mov r0, sl
 	mov r1, r8
 	mov r2, sb
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r5, #0
 	str r5, [sl, #0x1c]
 	cmp r4, #0
@@ -2439,7 +2439,7 @@ ov29_02347518: ; 0x02347518
 	add r1, r3, #4
 	mov r1, r1, lsl #8
 	mov r2, r2, lsl #8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 #ifdef JAPAN
 	mov r0, #0
 #else
@@ -2623,7 +2623,7 @@ _02347750:
 #else
 	mov r2, fp
 #endif
-	bl ov29_022E1A90
+	bl IncrementEntityPixelPosXY
 	bl IsWaterTileset
 	cmp r0, #0
 	ldr r0, [r4, #0xd8]

--- a/asm/overlay_29_02347BC8.s
+++ b/asm/overlay_29_02347BC8.s
@@ -44,7 +44,7 @@ ov29_02347BC8: ; 0x02347BC8
 	add r3, r3, #4
 	mov r1, r3, lsl #8
 	mov r2, r2, lsl #8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	mov r0, r5
 	str r0, [sp, #0x2c]
 	strh r0, [r4, #0xf2]
@@ -137,7 +137,7 @@ _02347D84:
 	add r8, r8, r0
 	add r0, r4, #0xcc
 	mov fp, r6, asr #8
-	bl ov29_022E1A84
+	bl SetEntityPixelPosXY
 	bl IsWaterTileset
 	cmp r0, #0
 	ldr r1, [sp, #0x34]

--- a/include/dg_object.h
+++ b/include/dg_object.h
@@ -8,7 +8,7 @@
 // return: bool
 u8 EntityIsValid__022E1A1C(struct entity *entity);
 void UpdateEntityPixelPos(struct entity *entity, struct pixel_position *pixel_pos);
-void ov29_022E1A84(struct entity *entity, u32 x, u32 y);
-void ov29_022E1A84(struct entity *entity, u32 x, u32 y);
+void SetEntityPixelPosXY(struct entity *entity, u32 x, u32 y);
+void IncrementEntityPixelPosXY(struct entity *entity, u32 x, u32 y);
 
 #endif //PMDSKY_OVERLAY_29_022E1A1C_H

--- a/include/dg_object.h
+++ b/include/dg_object.h
@@ -7,5 +7,8 @@
 // entity: entity pointer
 // return: bool
 u8 EntityIsValid__022E1A1C(struct entity *entity);
+void UpdateEntityPixelPos(struct entity *entity, struct pixel_position *pixel_pos);
+void ov29_022E1A84(struct entity *entity, u32 x, u32 y);
+void ov29_022E1A84(struct entity *entity, u32 x, u32 y);
 
 #endif //PMDSKY_OVERLAY_29_022E1A1C_H

--- a/main.lsf
+++ b/main.lsf
@@ -187,7 +187,7 @@ Overlay OVY_29
 	Object src/dg.o
 	Object asm/overlay_29_022E0378.o
 	Object src/dg_object.o
-	Object asm/overlay_29_022E1A40.o
+	Object asm/overlay_29_022E1AAC.o
 	Object src/dg_camera.o
 	Object asm/overlay_29_022E330C.o
 	Object src/dg_effect.o

--- a/src/dg_object.c
+++ b/src/dg_object.c
@@ -10,3 +10,27 @@ u8 EntityIsValid__022E1A1C(struct entity *entity)
     }
     return entity->type != ENTITY_NOTHING;
 }
+
+void UpdateEntityPixelPos(struct entity *entity, struct pixel_position *pixel_pos)
+{
+    if (pixel_pos != 0) {
+        entity->pixel_pos.x = pixel_pos->x;
+        entity->pixel_pos.y = pixel_pos->y;
+    }
+    else {
+        entity->pixel_pos.x = ((((entity->pos.x)*0x18)+0x0c)<<8);
+        entity->pixel_pos.y = ((((entity->pos.y)*0x18)+0x10)<<8);
+    }
+}
+
+void ov29_022E1A84(struct entity *entity, u32 x, u32 y)
+{
+    entity->pixel_pos.x = x;
+    entity->pixel_pos.y = y;
+}
+
+void ov29_022E1A84(struct entity *entity, u32 x, u32 y)
+{
+    entity->pixel_pos.x += x;
+    entity->pixel_pos.y += y;
+}

--- a/src/dg_object.c
+++ b/src/dg_object.c
@@ -23,13 +23,13 @@ void UpdateEntityPixelPos(struct entity *entity, struct pixel_position *pixel_po
     }
 }
 
-void ov29_022E1A84(struct entity *entity, u32 x, u32 y)
+void SetEntityPixelPosXY(struct entity *entity, u32 x, u32 y)
 {
     entity->pixel_pos.x = x;
     entity->pixel_pos.y = y;
 }
 
-void ov29_022E1A84(struct entity *entity, u32 x, u32 y)
+void IncrementEntityPixelPosXY(struct entity *entity, u32 x, u32 y)
 {
     entity->pixel_pos.x += x;
     entity->pixel_pos.y += y;


### PR DESCRIPTION
Hi, this is my first decompilation pull request to this repo! I'm 100% open to feedback on if there's a better way to decompile+rename functions if the decompilation sheds light on the purpose of the function.

Broken into 2 commits to make the two halves of this more clear, the rename commit is just a global search/replace of the relevant names.