### PR TITLE
ov15_0238AE98 decompiled

### DIFF
--- a/asm/include/overlay_15_0238AF54.inc
+++ b/asm/include/overlay_15_0238AF54.inc
@@ -1,16 +1,10 @@
 #pragma once
 .public CloseDialogueBox
 .public ClosePortraitBox
-.public Debug_Print0
 .public HidePortraitBox
 .public IsDialogueBoxActive
-.public MemFree
+.public OVERLAY15_UNKNOWN_POINTER__NA_238B180
 .public ov11_022E6E68
 .public ov15_0238A234
-.public ov15_0238B11C
-.public ov15_0238B12C
-.public ov15_0238B13C
-.public ov15_0238B150
-.public OVERLAY15_UNKNOWN_POINTER__NA_238B180
 .public sub_0202836C
 .public sub_0202F2C4

--- a/asm/overlay_15_0238AF54.s
+++ b/asm/overlay_15_0238AF54.s
@@ -1,63 +1,7 @@
 	.include "asm/macros.inc"
-	.include "overlay_15_0238AE98.inc"
+	.include "overlay_15_0238AF54.inc"
 
 	.text
-
-	arm_func_start ov15_0238AE98
-ov15_0238AE98: ; 0x0238AE98
-	stmdb sp!, {r3, lr}
-	ldr r0, _0238AF40 ; =OVERLAY15_UNKNOWN_POINTER__NA_238B180
-	ldr r0, [r0]
-	cmp r0, #0
-	ldmeqia sp!, {r3, pc}
-	ldrsb r1, [r0, #0x80]
-	mvn r0, #1
-	cmp r1, r0
-	beq _0238AEC4
-	ldr r0, _0238AF44 ; =ov15_0238B11C
-	bl Debug_Print0
-_0238AEC4:
-	ldr r1, _0238AF40 ; =OVERLAY15_UNKNOWN_POINTER__NA_238B180
-	mvn r0, #1
-	ldr r1, [r1]
-	ldrsb r1, [r1, #0x82]
-	cmp r1, r0
-	beq _0238AEE4
-	ldr r0, _0238AF48 ; =ov15_0238B12C
-	bl Debug_Print0
-_0238AEE4:
-	ldr r1, _0238AF40 ; =OVERLAY15_UNKNOWN_POINTER__NA_238B180
-	mvn r0, #1
-	ldr r1, [r1]
-	ldrsb r1, [r1, #0x83]
-	cmp r1, r0
-	beq _0238AF04
-	ldr r0, _0238AF4C ; =ov15_0238B13C
-	bl Debug_Print0
-_0238AF04:
-	ldr r1, _0238AF40 ; =OVERLAY15_UNKNOWN_POINTER__NA_238B180
-	mvn r0, #1
-	ldr r1, [r1]
-	ldrsb r1, [r1, #0x84]
-	cmp r1, r0
-	beq _0238AF24
-	ldr r0, _0238AF50 ; =ov15_0238B150
-	bl Debug_Print0
-_0238AF24:
-	ldr r0, _0238AF40 ; =OVERLAY15_UNKNOWN_POINTER__NA_238B180
-	ldr r0, [r0]
-	bl MemFree
-	ldr r0, _0238AF40 ; =OVERLAY15_UNKNOWN_POINTER__NA_238B180
-	mov r1, #0
-	str r1, [r0]
-	ldmia sp!, {r3, pc}
-	.align 2, 0
-_0238AF40: .word OVERLAY15_UNKNOWN_POINTER__NA_238B180
-_0238AF44: .word ov15_0238B11C
-_0238AF48: .word ov15_0238B12C
-_0238AF4C: .word ov15_0238B13C
-_0238AF50: .word ov15_0238B150
-	arm_func_end ov15_0238AE98
 
 	arm_func_start ov15_0238AF54
 ov15_0238AF54: ; 0x0238AF54
@@ -191,23 +135,6 @@ ov15_0238B10C:
 	.global ov15_0238B114
 ov15_0238B114:
 	.byte 0x47, 0x2D, 0x4F, 0x70, 0x65, 0x6E, 0x0A, 0x00
-	.global ov15_0238B11C
-ov15_0238B11C:
-	.byte 0x6D, 0x65, 0x73, 0x20, 0x6E, 0x6F, 0x74, 0x20
-	.byte 0x63, 0x6C, 0x6F, 0x73, 0x65, 0x0A, 0x00, 0x00
-	.global ov15_0238B12C
-ov15_0238B12C:
-	.byte 0x73, 0x75, 0x62, 0x20, 0x6E, 0x6F, 0x74, 0x20
-	.byte 0x63, 0x6C, 0x6F, 0x73, 0x65, 0x0A, 0x00, 0x00
-	.global ov15_0238B13C
-ov15_0238B13C:
-	.byte 0x73, 0x65, 0x6C, 0x65, 0x63, 0x74, 0x20, 0x6E
-	.byte 0x6F, 0x74, 0x20, 0x63, 0x6C, 0x6F, 0x73, 0x65, 0x0A, 0x00, 0x00, 0x00
-	.global ov15_0238B150
-ov15_0238B150:
-	.byte 0x49, 0x6E, 0x70, 0x75
-	.byte 0x74, 0x20, 0x6E, 0x6F, 0x74, 0x20, 0x63, 0x6C, 0x6F, 0x73, 0x65, 0x0A, 0x00, 0x00, 0x00, 0x00
-
 	.data
 	.global OVERLAY15_UNKNOWN_POINTER__NA_238B180
 OVERLAY15_UNKNOWN_POINTER__NA_238B180:

--- a/include/overlay_15_0238AD78.h
+++ b/include/overlay_15_0238AD78.h
@@ -8,6 +8,6 @@ typedef struct {
     s8 unk68;
 } unkStruct_ov15_0238AD78;
 
-void ov15_0238AD78(u32 r0);
+void ov15_0238AD78(u8 r0);
 
 #endif //PMDSKY_OVERLAY_15_0238AD78_H

--- a/include/overlay_15_0238AE6C.h
+++ b/include/overlay_15_0238AE6C.h
@@ -5,12 +5,20 @@ typedef struct {
     u8 fill0[0x54];
     u32 unk54;
     u8 fill58[0x68 - 0x58];
-    u32* unk68;
-    u8 fill3[0xd8 - 0x6c];
+    u32 unk68;
+    u8 fill3[0x80 - 0x6c];
+    s8 unk80;
+    u8 fill82[0x82 - 0x81];
+    s8 unk82;
+    s8 unk83;
+    s8 unk84;
+    u8 fillD8[0xD8 - 0x85];
     u8 unkD8;
 } unkStruct_ov15_0238AE6C;
 
 void ov15_0238AE6C(void);
 s32 ov15_0238AE88(void);
+void ov15_0238AE98(void);
 
 #endif //PMDSKY_OVERLAY_15_0238AE6C_H
+

--- a/main.lsf
+++ b/main.lsf
@@ -150,7 +150,7 @@ Overlay OVY_15
 	Object src/overlay_15_0238AD78.o
 	Object asm/overlay_15_0238ADC4.o
 	Object src/overlay_15_0238AE6C.o
-	Object asm/overlay_15_0238AE98.o
+	Object asm/overlay_15_0238AF54.o
 }
 Overlay OVY_16
 {

--- a/src/overlay_15_0238AD78.c
+++ b/src/overlay_15_0238AD78.c
@@ -5,7 +5,7 @@ extern unkStruct_ov15_0238AD78* OVERLAY15_UNKNOWN_POINTER__NA_238B180;
 extern void sub_02026268(u32, u32, u32, u16);
 extern void sub_02039B0C(u32*);
 
-void ov15_0238AD78(u32 r0) {
+void ov15_0238AD78(u8 r0) {
     #ifdef JAPAN
     u32 uVar1 = r0 != 0 ? 12873 : 12874;
     #else

--- a/src/overlay_15_0238AE6C.c
+++ b/src/overlay_15_0238AE6C.c
@@ -2,8 +2,10 @@
 
 extern unkStruct_ov15_0238AE6C* OVERLAY15_UNKNOWN_POINTER__NA_238B180;
 
-extern void ov15_0238A140(void);
-extern void ov15_0238AD78(u32);
+extern u16 ov15_0238A140(void);
+extern void ov15_0238AD78(u8);
+extern void Debug_Print0(const char* fmt);
+extern void MemFree(void*);
 
 void ov15_0238AE6C(void)
 {
@@ -14,4 +16,30 @@ s32 ov15_0238AE88(void)
 {
     ov15_0238A140();
     return 1;
+}
+
+const char ov15_0238B11C[] = "mes not close\n";
+const char ov15_0238B12C[] = "sub not close\n";
+const char ov15_0238B13C[] = "select not close\n";
+const char ov15_0238B150[] = "Input not close\n";
+
+void ov15_0238AE98(void)
+{
+    if (OVERLAY15_UNKNOWN_POINTER__NA_238B180 == NULL) {
+        return;
+    }
+    if (OVERLAY15_UNKNOWN_POINTER__NA_238B180->unk80 != -2) {
+        Debug_Print0(ov15_0238B11C);
+    }
+    if (OVERLAY15_UNKNOWN_POINTER__NA_238B180->unk82 != -2) {
+        Debug_Print0(ov15_0238B12C);
+    }
+    if (OVERLAY15_UNKNOWN_POINTER__NA_238B180->unk83 != -2) {
+        Debug_Print0(ov15_0238B13C);
+    }
+    if (OVERLAY15_UNKNOWN_POINTER__NA_238B180->unk84 != -2) {
+        Debug_Print0(ov15_0238B150);
+    }
+    MemFree(OVERLAY15_UNKNOWN_POINTER__NA_238B180);
+    OVERLAY15_UNKNOWN_POINTER__NA_238B180 = NULL;
 }


### PR DESCRIPTION
The char array literals added in overlay_15_0238AE6C.c are unfortunate but I could not get a matching ROM with just passing the corresponding string literals to Print_Debug0. Maybe the padding bytes are missing in a string literal represenation? But default behaviour for this platform should be "automatic" padding?