### PR TITLE
Fixed 'make install_toolchain' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ install_toolchain:
 	wget https://github.com/pret/pmd-sky/raw/workflows/assets/NitroSDK-4_2-071210-jp.7z -O toolchain_tmp/NitroSDK-4_2-071210-jp.7z
 	unzip -o toolchain_tmp/mwccarm.zip -d tools
 	7z x toolchain_tmp/NitroSDK-4_2-071210-jp.7z -otoolchain_tmp/nitro_sdk -y
-	mv toolchain_tmp/nitro_sdk/tools/bin/* tools/bin
+	mv toolchain_tmp/nitro_sdk/tools/bin tools/
 	mv toolchain_tmp/nitro_sdk/include/nitro/specfiles/ARM7-TS.lcf.template sub/
 	mv toolchain_tmp/nitro_sdk/include/nitro/specfiles/ARM9-TS.lcf.template .
 	mv toolchain_tmp/nitro_sdk/include/nitro/specfiles/mwldarm.response.template .


### PR DESCRIPTION
Changed: 
mv toolchain_tmp/nitro_sdk/tools/bin/* tools/bin
to:
mv toolchain_tmp/nitro_sdk/tools/bin tools/
before it would error with tools/bin not existing.