### PR TITLE
Skip webhook if secret is missing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         run: make -j${nproc}
 
       - name: Webhook
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.CALCROM_WEBHOOK_URL != '' }}
         run: |
           sudo chmod 755 $GITHUB_WORKSPACE/.github/calcrom/webhook.sh
           $GITHUB_WORKSPACE/.github/calcrom/webhook.sh pmdsky "$CALCROM_WEBHOOK_URL"


### PR DESCRIPTION
When enabling actions on a fork this secret isn't available and causes a `Process completed with exit code 2.` error from curl being run with too few arguments.