### PR TITLE
Decompile RevealAttackedTile and ResetVictoryCounter

### DIFF
--- a/asm/include/overlay_29_022DEBA4.inc
+++ b/asm/include/overlay_29_022DEBA4.inc
@@ -159,7 +159,7 @@
 .public ov29_023369F8
 .public ov29_0233781C
 .public ov29_0233785C
-.public ov29_0233845C
+.public ResetVictoryCounter
 .public ov29_0233873C
 .public ov29_023389C4
 .public ov29_02338A4C

--- a/asm/overlay_29_022DEBA4.s
+++ b/asm/overlay_29_022DEBA4.s
@@ -763,7 +763,7 @@ _022DF660:
 	bl ov29_022E12F8
 	cmp r5, #0
 	bne _022DF68C
-	bl ov29_0233845C
+	bl ResetVictoryCounter
 	bl GenerateFloor
 	ldrb r0, [sb, #0x748]
 	bl GetTurnLimit

--- a/asm/overlay_29_023383A8.s
+++ b/asm/overlay_29_023383A8.s
@@ -3,38 +3,6 @@
 
 	.text
 
-	arm_func_start RevealAttackedTile
-RevealAttackedTile: ; 0x02338430
-	stmdb sp!, {r4, lr}
-	mov r4, r0
-	mov r1, #1
-	bl TryRevealAttackedTrap
-	mov r0, r4
-	bl PositionIsOnHiddenStairs
-	cmp r0, #0
-	ldmeqia sp!, {r4, pc}
-	mov r0, #1
-	bl HiddenStairsTrigger
-	ldmia sp!, {r4, pc}
-	arm_func_end RevealAttackedTile
-
-	arm_func_start ov29_0233845C
-ov29_0233845C: ; 0x0233845C
-	ldr r1, _02338474 ; =DUNGEON_PTR
-	ldr r0, _02338478 ; =0x00012AFE
-	ldr r1, [r1]
-	mov r2, #0
-	strh r2, [r1, r0]
-	bx lr
-	.align 2, 0
-_02338474: .word DUNGEON_PTR
-#ifdef JAPAN
-_02338478: .word 0x00012A5A
-#else
-_02338478: .word 0x00012AFE
-#endif
-	arm_func_end ov29_0233845C
-
 	arm_func_start ov29_0233847C
 ov29_0233847C: ; 0x0233847C
 	stmdb sp!, {r4, lr}

--- a/include/overlay_29_023383A8.h
+++ b/include/overlay_29_023383A8.h
@@ -1,0 +1,9 @@
+#ifndef PMDSKY_OVERLAY_29_023383A8_H
+#define PMDSKY_OVERLAY_29_023383A8_H
+
+#include "dungeon_mode.h"
+
+void RevealAttackedTile(struct position *pos);
+void ResetVictoryCounter();
+
+#endif //PMDSKY_OVERLAY_29_023383A8_H

--- a/main.lsf
+++ b/main.lsf
@@ -696,6 +696,7 @@ Overlay OVY_29
 	Object asm/overlay_29_02337EC0.o
 	Object src/overlay_29_02338350.o
 	Object src/overlay_29_0233836C.o
+	Object src/overlay_29_023383a8_0.o
 	Object asm/overlay_29_023383A8.o
 	Object src/overlay_29_02338548.o
 	Object src/overlay_29_02338560.o

--- a/src/overlay_29_023383a8_0.c
+++ b/src/overlay_29_023383a8_0.c
@@ -1,0 +1,21 @@
+#include "overlay_29_023383A8.h"
+
+#include "dungeon.h"
+#include "dungeon_mode.h"
+
+extern void TryRevealAttackedTrap(struct position* pos, int param1);
+extern bool32 PositionIsOnHiddenStairs(struct position* pos);
+extern void HiddenStairsTrigger(bool32 param0);
+
+void RevealAttackedTile(struct position *pos) {
+    TryRevealAttackedTrap(pos, 1);
+    if (PositionIsOnHiddenStairs(pos) == FALSE) {
+        return;
+    }
+    HiddenStairsTrigger(TRUE);
+}
+
+
+void ResetVictoryCounter() {
+    DUNGEON_PTR[0]->victory_counter = 0;
+}


### PR DESCRIPTION
Decompile `RevealAttackedTile` and `ResetVictoryCounter`
`ov29_0233845C` was documented as `ResetVictoryCounter`