### PR TITLE
IsSkyExclusiveDungeon (Claude Matched, Human Confirmed)

### DIFF
--- a/asm/main_02051504.s
+++ b/asm/main_02051504.s
@@ -191,15 +191,3 @@ IsExpEnabledInDungeon: ; 0x0205171C
 	.align 2, 0
 _02051740: .word DUNGEON_RESTRICTIONS
 	arm_func_end IsExpEnabledInDungeon
-
-	arm_func_start IsSkyExclusiveDungeon
-IsSkyExclusiveDungeon: ; 0x02051744
-	cmp r0, #0x67
-	blo _02051758
-	cmp r0, #0xb0
-	movls r0, #1
-	bxls lr
-_02051758:
-	mov r0, #0
-	bx lr
-	arm_func_end IsSkyExclusiveDungeon

--- a/include/main_02051760.h
+++ b/include/main_02051760.h
@@ -1,8 +1,10 @@
 #ifndef PMDSKY_MAIN_02051760_H
 #define PMDSKY_MAIN_02051760_H
 
+#include "enums.h"
 #include "util.h"
 
+bool8 IsSkyExclusiveDungeon(enum dungeon_id dungeon_id);
 bool32 JoinedAtRangeCheck2(u8 joined_at);
 
 #endif //PMDSKY_MAIN_02051760_H

--- a/src/main_02051760.c
+++ b/src/main_02051760.c
@@ -2,6 +2,14 @@
 #include "enums.h"
 #include "util.h"
 
+bool8 IsSkyExclusiveDungeon(enum dungeon_id dungeon_id)
+{
+    if (dungeon_id >= DUNGEON_ZERO_ISLE_CENTER && dungeon_id <= DUNGEON_ARMALDOS_SHELTER) {
+        return TRUE;
+    }
+    return FALSE;
+}
+
 bool32 JoinedAtRangeCheck2(u8 joined_at) {
     return joined_at == DUNGEON_BEACH || (joined_at >= DUNGEON_DUMMY_0xEC && DUNGEON_DUMMY_0xF0 >= joined_at);
 }


### PR DESCRIPTION
**AI-authored — Claude (Opus 4.8), under human direction.** Claude can make
mistakes; please review the diff and re-verify the matching build before merging.

Decompiles `IsSkyExclusiveDungeon` — a `DUNGEON_ZERO_ISLE_CENTER … DUNGEON_ARMALDOS_SHELTER`
(0x67–0xb0) range predicate.

**Verification:** matched on decomp.me (score 0) with the preset-101 flags, then
confirmed by a full matching build — `build/pmdsky.us/pmdsky.us.nds: OK`.

Generated with [Claude Code](https://claude.com/claude-code)